### PR TITLE
fix github action

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -2,7 +2,7 @@ name: GH-Pages
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
 jobs:


### PR DESCRIPTION
    Fix github action event trigger
    
    GH-Pages action listens for pushes on master, but the repository already
    works on the new naming scheme where main is the default branch.

